### PR TITLE
Fix: Fixing alert title on stories

### DIFF
--- a/packages/alert/src/lib/alert.stories.mdx
+++ b/packages/alert/src/lib/alert.stories.mdx
@@ -148,7 +148,7 @@ The `Alert` could have title and description.
               <Stack spacing={1}>
                 <Typography variant="body">Without title</Typography>
                 <Alert action={<Typography variant="body2">Action</Typography>} onClose={()=>{}}>
-                  Alert without title. dsa dsa dsa dsa dsa
+                  Alert without title
                 </Alert>
               </Stack>
             </Grid>


### PR DESCRIPTION
Removing unnecessary words from alert title story.